### PR TITLE
update calls to method replaced in Play for jdk9 compatibility

### DIFF
--- a/app/views/tags/crud/form.html
+++ b/app/views/tags/crud/form.html
@@ -1,10 +1,10 @@
 %{
     if(_object) {
         currentObject = _object
-        currentType = _('controllers.CRUD$ObjectType').forClass(_object.getClass().getName())
+        currentType = __loadClass('controllers.CRUD$ObjectType').forClass(_object.getClass().getName())
     } else if(_class) {
         currentObject = null;
-        currentType = _('controllers.CRUD$ObjectType').forClass(_class)
+        currentType = __loadClass('controllers.CRUD$ObjectType').forClass(_class)
     } else {
         currentObject = _caller.object
         currentType = _caller.type

--- a/app/views/tags/crud/types.tag
+++ b/app/views/tags/crud/types.tag
@@ -1,13 +1,13 @@
 %{
     models = [];
-    for(controllerClass in play.Play.classloader.getAssignableClasses(_('controllers.CRUD'))) {
-        resourceModel = _('controllers.CRUD$ObjectType').get(controllerClass)
+    for(controllerClass in play.Play.classloader.getAssignableClasses(__loadClass('controllers.CRUD'))) {
+        resourceModel = __loadClass('controllers.CRUD$ObjectType').get(controllerClass)
         if(resourceModel != null) {
             models.add(resourceModel)
         }
     }
-    for(controllerClass in play.Play.classloader.getAssignableClasses(_('play.scalasupport.crud.CRUDWrapper'))) {
-        resourceModel = _('controllers.CRUD$ObjectType').get(controllerClass)
+    for(controllerClass in play.Play.classloader.getAssignableClasses(__loadClass('play.scalasupport.crud.CRUDWrapper'))) {
+        resourceModel = __loadClass('controllers.CRUD$ObjectType').get(controllerClass)
         if(resourceModel != null) {
             models.add(resourceModel)
         }


### PR DESCRIPTION
I replaced the the shorthand methods `_(String className)` that have been removed from Play's `GroovyTemplate` class for compatibility with jdk 9 (see https://github.com/playframework/play1/pull/1252)